### PR TITLE
Claims button should by default open inventory panel

### DIFF
--- a/src/ClaimsNotification.jsx
+++ b/src/ClaimsNotification.jsx
@@ -39,6 +39,7 @@ const ClaimsNotification = () => {
 
     setState({
       openedPanel: 'CharacterPanel',
+      openedTab: 'Inventory',
     });
   };
 

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -40,7 +40,7 @@ import {ClaimsNotification} from '../../ClaimsNotification.jsx';
 import {DomRenderer} from '../../DomRenderer.jsx';
 import {BuildVersion} from '../general/build-version/BuildVersion.jsx';
 import {handleStoryKeyControls} from '../../../story';
-import { GrabKeyIndicators } from '../../GrabKeyIndicators';
+import {GrabKeyIndicators} from '../../GrabKeyIndicators';
 
 import styles from './App.module.css';
 import '../../fonts.css';
@@ -104,7 +104,7 @@ const useWebaverseApp = (() => {
 })();
 
 export const App = () => {
-  const [state, setState] = useState({openedPanel: null});
+  const [state, setState] = useState({openedPanel: null, openedTab: null});
   const [uiMode, setUIMode] = useState('normal');
 
   const canvasRef = useRef(null);

--- a/src/components/general/equipment/Equipment.jsx
+++ b/src/components/general/equipment/Equipment.jsx
@@ -406,6 +406,27 @@ export const Equipment = () => {
           abortController.abort();
         };
       }
+
+      if (state.openedTab) {
+        let selectedTab;
+        switch (state.openedTab) {
+          case 'Inventory':
+            selectedTab = 0;
+            break;
+          case 'Account':
+            selectedTab = 1;
+            break;
+          case 'Land':
+            selectedTab = 2;
+            break;
+          default:
+            selectedTab = 1;
+            break;
+        }
+        const delta = selectedTab - selectedMenuIndex;
+        setFaceIndex(faceIndex + delta);
+        sounds.playSoundName('menuNext');
+      }
     } else {
       if (selectObject) {
         setSelectObject(null);

--- a/src/components/play-mode/hotbar/Hotbar.jsx
+++ b/src/components/play-mode/hotbar/Hotbar.jsx
@@ -1,95 +1,96 @@
 import React, {useState, useContext, useRef, useEffect} from 'react';
 import classnames from 'classnames';
-import { AppContext } from '../../app';
+import {AppContext} from '../../app';
 import styles from './hotbar.module.css';
 import {HotBox} from '../hotbox/HotBox.jsx';
 
 import game from '../../../../game.js';
 import loadoutManager from '../../../../loadout-manager.js';
-import {registerIoEventHandler, unregisterIoEventHandler} from '../../general/io-handler/IoHandler.jsx';
+import {
+  registerIoEventHandler,
+  unregisterIoEventHandler,
+} from '../../general/io-handler/IoHandler.jsx';
 import {hotbarSize, numLoadoutSlots} from '../../../../constants.js';
 
-export const Hotbar = ({ className }) => {
-    const { state, setState } = useContext( AppContext );
-    const open =  state.openedPanel === 'CharacterPanel';
+export const Hotbar = ({className}) => {
+  const {state, setState} = useContext(AppContext);
+  const open = state.openedPanel === 'CharacterPanel';
 
-    useEffect(() => {
-        if (open) {
-            const keydown = e => {
-                if (!e.ctrlKey) {
-                    switch (e.which) {
-                        case 82: { // R
-                            game.dropSelectedApp();
-                            return false;
-                        }
-                        case 46: { // delete
-                            game.deleteSelectedApp();
-                            return false;
-                        }
-                    }
-                }
-            };
-            registerIoEventHandler('keydown', keydown);
-
-            return () => {
-                unregisterIoEventHandler('keydown', keydown);
-            };
-        }
-    }, [open]);
-
-    const onDragOver = index => e => {
-        e.preventDefault();
-    };
-    const onDrop = index => e => {
-        e.preventDefault();
-        e.stopPropagation();
-        
-        game.handleDropJsonItemToPlayer(e.dataTransfer.items[0], index);
-    };
-    const onTopClick = e => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        setState({
-            openedPanel: 'CharacterPanel',
-        });
-    };
-    const onBottomClick = index => e => {
-        loadoutManager.setSelectedIndex(index);
-    };
-
-    return (
-        <div
-            className={ classnames( className, styles.hotbar, open ? styles.open : null ) }
-            onClick={onTopClick}
-        >
-
-            {
-                ( () => {
-
-                    const items = Array( numLoadoutSlots );
-
-                    for ( let i = 0; i < numLoadoutSlots; i ++ ) {
-
-                        items[ i ] = (
-                            <HotBox
-                              size={hotbarSize}
-                              onDragOver={onDragOver(i)}
-                              onDrop={onDrop(i)}
-                              onClick={onBottomClick(i)}
-                              index={i}
-                              key={i}
-                            />
-                        );
-
-                    }
-
-                    return items;
-
-                })()
+  useEffect(() => {
+    if (open) {
+      const keydown = e => {
+        if (!e.ctrlKey) {
+          switch (e.which) {
+            case 82: {
+              // R
+              game.dropSelectedApp();
+              return false;
             }
+            case 46: {
+              // delete
+              game.deleteSelectedApp();
+              return false;
+            }
+          }
+        }
+      };
+      registerIoEventHandler('keydown', keydown);
 
-        </div>
-    );
+      return () => {
+        unregisterIoEventHandler('keydown', keydown);
+      };
+    }
+  }, [open]);
 
+  const onDragOver = index => e => {
+    e.preventDefault();
+  };
+  const onDrop = index => e => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    game.handleDropJsonItemToPlayer(e.dataTransfer.items[0], index);
+  };
+  const onTopClick = e => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setState({
+      openedPanel: 'CharacterPanel',
+      openedTab: 'Inventory',
+    });
+  };
+  const onBottomClick = index => e => {
+    loadoutManager.setSelectedIndex(index);
+  };
+
+  return (
+    <div
+      className={classnames(
+        className,
+        styles.hotbar,
+        open ? styles.open : null,
+      )}
+      onClick={onTopClick}
+    >
+      {(() => {
+        const items = Array(numLoadoutSlots);
+
+        for (let i = 0; i < numLoadoutSlots; i++) {
+          items[i] = (
+            <HotBox
+              size={hotbarSize}
+              onDragOver={onDragOver(i)}
+              onDrop={onDrop(i)}
+              onClick={onBottomClick(i)}
+              index={i}
+              key={i}
+            />
+          );
+        }
+
+        return items;
+      })()}
+    </div>
+  );
 };


### PR DESCRIPTION
## Describe your changes
Added a new state so whenever we need it we can specify a tab to open.

## What are the steps for a QA tester to test this pull request?
Open character menu switch through the tabs of the equipment box.
Then close and press inventory button to open the character menu with the inventory tab open.

## Issue ticket number and link
https://github.com/webaverse/app/issues/3387

## Screenshots and/or video
https://user-images.githubusercontent.com/46432435/193220605-7ca752ba-868d-444b-9f3c-871823ca3b53.mp4


## Checklist before requesting a review
- [*] I have performed a self-review of my code
- [*] I am not adding any irrelevant code or assets
- [*] I am only including the changes needed to implement the change
- [*] I have playtested and intentionally tried to find error cases but couldn't
- [*] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR
