### PR TITLE
fix avatar optimizer crash

### DIFF
--- a/game.js
+++ b/game.js
@@ -1729,11 +1729,9 @@ class GameManager extends EventTarget {
       }
     };
 
-    // local player
+    // local party members
     const localPlayer = playersManager.getLocalPlayer();
-    localPlayer.avatar.setQuality(quality);
 
-    // party members
     for (const app of localPlayer.appManager.apps) {
       applySettingToApp(app);
     }


### PR DESCRIPTION
This is still in draft mode, because `VRMMaterialImporter` is currently not supported by our `three-vrm` version.